### PR TITLE
feat: switch REPLACE INTO -> INSERT ON DUPLICATE KEY UPDATE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,7 @@ COPY --from=builder /app/bin /app/bin
 WORKDIR /app
 USER app
 
+# override rocket's dev env defaulting to localhost
+ENV ROCKET_ADDRESS 0.0.0.0
+
 CMD ["/app/bin/megaphone"]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -101,9 +101,9 @@ impl BearerTokenAuthenticator {
         Ok(())
     }
 
-    /// Determine if Bearer token is for an authenticated user
-    fn authenticated_user(&self, token: &str) -> HandlerResult<(UserId, Group)> {
-        let parts: Vec<_> = token.splitn(2, ' ').collect();
+    /// Determine if Bearer token header is for an authenticated user
+    fn authenticated_user(&self, credentials: &str) -> HandlerResult<(UserId, Group)> {
+        let parts: Vec<_> = credentials.splitn(2, ' ').collect();
         if parts.len() != 2 || parts[0].to_lowercase() != "bearer" {
             Err(HandlerErrorKind::InvalidAuth)?
         }
@@ -120,14 +120,14 @@ impl BearerTokenAuthenticator {
 }
 
 fn authenticated_user(request: &Request) -> HandlerResult<(UserId, Group)> {
-    let auth_header = request
+    let credentials = request
         .headers()
         .get_one("Authorization")
         .ok_or_else(|| HandlerErrorKind::MissingAuth)?;
     request
         .guard::<State<BearerTokenAuthenticator>>()
         .success_or(HandlerErrorKind::InternalError)?
-        .authenticated_user(auth_header)
+        .authenticated_user(credentials)
 }
 
 pub fn authorized_broadcaster(request: &Request) -> HandlerResult<Broadcaster> {

--- a/src/db/upsert_broadcast.sql
+++ b/src/db/upsert_broadcast.sql
@@ -1,0 +1,3 @@
+INSERT INTO broadcastsv1 (broadcaster_id, bchannel_id, version)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE version = ?;


### PR DESCRIPTION
diesel refuses to support the latter due to its many gotchas but for
our simple setup it's nicer than REPLACE INTO

also:

o switch POST -> PUT and return 201 when newly created
o force binding to all interfaces for deploym

Closes #19