### PR TITLE
chore: tag 0.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: docker:17.12.1-ce
+      - image: docker:18.03.0-ce
     working_directory: /dockerflow
     steps:
+      - run:
+          name: Install Docker build dependencies
+          command: apk add --no-cache openssh-client git
+
       - checkout
       - setup_remote_docker
 
@@ -42,7 +46,7 @@ jobs:
 
   deploy:
     docker:
-      - image: docker:17.12.1-ce
+      - image: docker:18.03.0-ce
     steps:
       - setup_remote_docker
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+<a name="0.1.0"></a>
+## 0.1.0 (2018-04-05)
+
+
+#### Bug Fixes
+
+*   use mysql, not postgres ([0130713f](https://github.com/mozilla-services/megaphone/commit/0130713fac7f30b986043f7d0ea74e40a234cecb))
+
+#### Features
+
+*   peg Docker build to rust nightly-2018-04-04 ([f17d4924](https://github.com/mozilla-services/megaphone/commit/f17d4924e2f0a74026540e47cbc3a669acc071f9), closes [#25](https://github.com/mozilla-services/megaphone/issues/25))
+*   peg builds w/ a Cargo.lock ([e359991f](https://github.com/mozilla-services/megaphone/commit/e359991f235b7f5c1e9eee5e1ef0f51d2419d3a2), closes [#29](https://github.com/mozilla-services/megaphone/issues/29))
+*   add a .clog.toml and CONTRIBUTING.md ([f2a33e7a](https://github.com/mozilla-services/megaphone/commit/f2a33e7a578a67da593aa6491396e0a184d101c1), closes [#27](https://github.com/mozilla-services/megaphone/issues/27))
+*   switch REPLACE INTO -> INSERT ON DUPLICATE KEY UPDATE ([f09af1c0](https://github.com/mozilla-services/megaphone/commit/f09af1c0cdf807deae7863ad034b3e2caf5c0ec5), closes [#19](https://github.com/mozilla-services/megaphone/issues/19))
+*   return WWW-Authenticate on 401s ([348f3e91](https://github.com/mozilla-services/megaphone/commit/348f3e919380c5d3f7ea8913c6d1fbced593feb9), closes [#21](https://github.com/mozilla-services/megaphone/issues/21))
+*   use diesel's embedded migrations ([64e00c83](https://github.com/mozilla-services/megaphone/commit/64e00c83e43542ff86dfdcbd8e674395b858ce6e), closes [#17](https://github.com/mozilla-services/megaphone/issues/17))
+*   cleanup Config usage ([e5ddf43e](https://github.com/mozilla-services/megaphone/commit/e5ddf43ef1ac910b1202fc6c687fd1d828fafb0c), closes [#16](https://github.com/mozilla-services/megaphone/issues/16))
+*   handle auth via Bearer tokens ([91e28568](https://github.com/mozilla-services/megaphone/commit/91e28568b2b28f51642b29d649c23b3f71b3e767), closes [#7](https://github.com/mozilla-services/megaphone/issues/7))
+*   add Dockerflow styled health/version checks ([cb616611](https://github.com/mozilla-services/megaphone/commit/cb61661172906fed34ce0b1ba12ee7796fde61f4), closes [#11](https://github.com/mozilla-services/megaphone/issues/11))
+*   add a Dockerfile based on debian stretch-slim ([e66b6cc9](https://github.com/mozilla-services/megaphone/commit/e66b6cc98905823ab36b808bf1b8d06c6da74a02), closes [#12](https://github.com/mozilla-services/megaphone/issues/12))
+*   initial prototype from the wip branch ([9e6f9b28](https://github.com/mozilla-services/megaphone/commit/9e6f9b289b12df6e5f10ac4a0f1d07ffce5b2777))
+
+
+
+<a name="0.1.0"></a>
+## 0.1.0 (2018-04-05)
+
+
+#### Bug Fixes
+
+*   use mysql, not postgres ([0130713f](https://github.com/mozilla-services/megaphone/commit/0130713fac7f30b986043f7d0ea74e40a234cecb))
+
+#### Features
+
+*   peg Docker build to rust nightly-2018-04-04 ([f17d4924](https://github.com/mozilla-services/megaphone/commit/f17d4924e2f0a74026540e47cbc3a669acc071f9), closes [#25](https://github.com/mozilla-services/megaphone/issues/25))
+*   peg builds w/ a Cargo.lock ([e359991f](https://github.com/mozilla-services/megaphone/commit/e359991f235b7f5c1e9eee5e1ef0f51d2419d3a2), closes [#29](https://github.com/mozilla-services/megaphone/issues/29))
+*   add a .clog.toml and CONTRIBUTING.md ([f2a33e7a](https://github.com/mozilla-services/megaphone/commit/f2a33e7a578a67da593aa6491396e0a184d101c1), closes [#27](https://github.com/mozilla-services/megaphone/issues/27))
+*   switch REPLACE INTO -> INSERT ON DUPLICATE KEY UPDATE ([f09af1c0](https://github.com/mozilla-services/megaphone/commit/f09af1c0cdf807deae7863ad034b3e2caf5c0ec5), closes [#19](https://github.com/mozilla-services/megaphone/issues/19))
+*   return WWW-Authenticate on 401s ([348f3e91](https://github.com/mozilla-services/megaphone/commit/348f3e919380c5d3f7ea8913c6d1fbced593feb9), closes [#21](https://github.com/mozilla-services/megaphone/issues/21))
+*   use diesel's embedded migrations ([64e00c83](https://github.com/mozilla-services/megaphone/commit/64e00c83e43542ff86dfdcbd8e674395b858ce6e), closes [#17](https://github.com/mozilla-services/megaphone/issues/17))
+*   cleanup Config usage ([e5ddf43e](https://github.com/mozilla-services/megaphone/commit/e5ddf43ef1ac910b1202fc6c687fd1d828fafb0c), closes [#16](https://github.com/mozilla-services/megaphone/issues/16))
+*   handle auth via Bearer tokens ([91e28568](https://github.com/mozilla-services/megaphone/commit/91e28568b2b28f51642b29d649c23b3f71b3e767), closes [#7](https://github.com/mozilla-services/megaphone/issues/7))
+*   add Dockerflow styled health/version checks ([cb616611](https://github.com/mozilla-services/megaphone/commit/cb61661172906fed34ce0b1ba12ee7796fde61f4), closes [#11](https://github.com/mozilla-services/megaphone/issues/11))
+*   add a Dockerfile based on debian stretch-slim ([e66b6cc9](https://github.com/mozilla-services/megaphone/commit/e66b6cc98905823ab36b808bf1b8d06c6da74a02), closes [#12](https://github.com/mozilla-services/megaphone/issues/12))
+*   initial prototype from the wip branch ([9e6f9b28](https://github.com/mozilla-services/megaphone/commit/9e6f9b289b12df6e5f10ac4a0f1d07ffce5b2777))
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.1.1"></a>
+## 0.1.1 (2018-04-06)
+
+
+#### Chore
+
+*   install openssh-client git & git on docker-in-docker ([f81d556a](https://github.com/mozilla-services/megaphone/commit/f81d556a415d7e775e358373df22e125d0c37406))
+
+
+
 <a name="0.1.0"></a>
 ## 0.1.0 (2018-04-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megaphone"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["jrconlin <me+crypt@jrconlin.com>"]
 
 [dependencies]


### PR DESCRIPTION
*phew* thank goodness this worked around the issue in #32

circleci's "fallback" git wound up with a corrupt repo somehow when checking out a tag, erroring out with "object not found": https://circleci.com/gh/mozilla-services/megaphone/86