### PR TITLE
[Fix #79] Fix example env vars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ All calls to Megaphone (minus the Dockerflow Status Checks) require authorizatio
 e.g.
 
 ```
-export ROCKET_BROADCASTER_AUTH={test="foobar"}
-export ROCKET_READER_AUTH={autopush="quux"}
+export ROCKET_BROADCASTER_AUTH={test=["foobar"]}
+export ROCKET_READER_AUTH={autopush=["quux"]}
 ```
 
 The *test* broadcaster would specify:


### PR DESCRIPTION
This will fix the environment variable that is defined in the readme.